### PR TITLE
The `asm!` macro was renamed to `llvm_asm!`

### DIFF
--- a/crates/cpuio/src/lib.rs
+++ b/crates/cpuio/src/lib.rs
@@ -1,7 +1,7 @@
 //! CPU-level input/output instructions, including `inb`, `outb`, etc., and
 //! a high level Rust wrapper.
 
-#![feature(asm, const_fn, no_std)]
+#![feature(llvm_asm, const_fn, no_std)]
 #![no_std]
 
 use core::marker::PhantomData;

--- a/crates/cpuio/src/x86.rs
+++ b/crates/cpuio/src/x86.rs
@@ -5,35 +5,35 @@ pub unsafe fn inb(port: u16) -> u8 {
     // The registers for the `in` and `out` instructions are always the
     // same: `a` for value, and `d` for the port address.
     let result: u8;
-    asm!("inb %dx, %al" : "={al}"(result) : "{dx}"(port) :: "volatile");
+    llvm_asm!("inb %dx, %al" : "={al}"(result) : "{dx}"(port) :: "volatile");
     result
 }
 
 /// Write a `u8`-sized `value` to `port`.
 pub unsafe fn outb(value: u8, port: u16) {
-    asm!("outb %al, %dx" :: "{dx}"(port), "{al}"(value) :: "volatile");
+    llvm_asm!("outb %al, %dx" :: "{dx}"(port), "{al}"(value) :: "volatile");
 }
 
 /// Read a `u16`-sized value from `port`.
 pub unsafe fn inw(port: u16) -> u16 {
     let result: u16;
-    asm!("inw %dx, %ax" : "={ax}"(result) : "{dx}"(port) :: "volatile");
+    llvm_asm!("inw %dx, %ax" : "={ax}"(result) : "{dx}"(port) :: "volatile");
     result
 }
 
 /// Write a `u8`-sized `value` to `port`.
 pub unsafe fn outw(value: u16, port: u16) {
-    asm!("outw %ax, %dx" :: "{dx}"(port), "{ax}"(value) :: "volatile");
+    llvm_asm!("outw %ax, %dx" :: "{dx}"(port), "{ax}"(value) :: "volatile");
 }
 
 /// Read a `u32`-sized value from `port`.
 pub unsafe fn inl(port: u16) -> u32 {
     let result: u32;
-    asm!("inl %dx, %eax" : "={eax}"(result) : "{dx}"(port) :: "volatile");
+    llvm_asm!("inl %dx, %eax" : "={eax}"(result) : "{dx}"(port) :: "volatile");
     result
 }
 
 /// Write a `u32`-sized `value` to `port`.
 pub unsafe fn outl(value: u32, port: u16) {
-    asm!("outl %eax, %dx" :: "{dx}"(port), "{eax}"(value) :: "volatile");
+    llvm_asm!("outl %eax, %dx" :: "{dx}"(port), "{eax}"(value) :: "volatile");
 }


### PR DESCRIPTION
This fixes compilation on latest nightly.