### PR TITLE
PIC: Masks

### DIFF
--- a/crates/pic8259_simple/src/lib.rs
+++ b/crates/pic8259_simple/src/lib.rs
@@ -81,7 +81,7 @@ impl ChainedPics {
                     command: cpuio::UnsafePort::new(0xA0),
                     data: cpuio::UnsafePort::new(0xA1),
                 },
-            ]
+            ],
         }
     }
 
@@ -97,7 +97,7 @@ impl ChainedPics {
         // allegedly takes long enough to make everything work on most
         // hardware.  Here, `wait` is a closure.
         let mut wait_port: cpuio::Port<u8> = cpuio::Port::new(0x80);
-        let mut wait = || { wait_port.write(0) };
+        let mut wait = || wait_port.write(0);
 
         // Save our original interrupt masks, because I'm too lazy to
         // figure out reasonable values.  We'll restore these when we're


### PR DESCRIPTION
Similar to #4.

This approach for adding support for interrupt masking adds methods to read and write both masks. I also added a function to disable the PIC by masking all interrupts.

What do you think?