### PR TITLE
cpuio: Use new feature flag for const functions

### DIFF
--- a/crates/cpuio/src/lib.rs
+++ b/crates/cpuio/src/lib.rs
@@ -1,7 +1,7 @@
 //! CPU-level input/output instructions, including `inb`, `outb`, etc., and
 //! a high level Rust wrapper.
 
-#![feature(llvm_asm, const_fn)]
+#![feature(llvm_asm, const_fn_trait_bound)]
 #![no_std]
 
 use core::marker::PhantomData;


### PR DESCRIPTION
This is necessary since rust-lang/rust#84310, otherwise new nightlies can't build cpuio.

Unfortunately, merging this means older nightlies can no longer compile the crate since new feature flags yield errors on nightlies that don't recognize it yet. 

Fixes #8.