### PR TITLE
cpuio: update to use the asm macro

### DIFF
--- a/crates/cpuio/src/lib.rs
+++ b/crates/cpuio/src/lib.rs
@@ -1,7 +1,6 @@
 //! CPU-level input/output instructions, including `inb`, `outb`, etc., and
 //! a high level Rust wrapper.
 
-#![feature(llvm_asm, const_fn)]
 #![no_std]
 
 use core::marker::PhantomData;

--- a/crates/cpuio/src/x86.rs
+++ b/crates/cpuio/src/x86.rs
@@ -1,39 +1,41 @@
 //! Rust wrappers around the x86-family I/O instructions.
 
+use core::arch::asm;
+
 /// Read a `u8`-sized value from `port`.
 pub unsafe fn inb(port: u16) -> u8 {
     // The registers for the `in` and `out` instructions are always the
     // same: `a` for value, and `d` for the port address.
     let result: u8;
-    llvm_asm!("inb %dx, %al" : "={al}"(result) : "{dx}"(port) :: "volatile");
+    asm!("inb dx", out("al") result, in("dx") port, options(pure, nomem));
     result
 }
 
 /// Write a `u8`-sized `value` to `port`.
-pub unsafe fn outb(value: u8, port: u16) {
-    llvm_asm!("outb %al, %dx" :: "{dx}"(port), "{al}"(value) :: "volatile");
+pub unsafe fn outb(value: u8, mut _port: u16) {
+    asm!("outb dx", out("dx") _port, in("al") value, options(pure, nomem));
 }
 
 /// Read a `u16`-sized value from `port`.
 pub unsafe fn inw(port: u16) -> u16 {
-    let result: u16;
-    llvm_asm!("inw %dx, %ax" : "={ax}"(result) : "{dx}"(port) :: "volatile");
+    let mut result: u16;
+    asm!("inw dx", out("ax") result, in("dx") port, options(pure, nomem));
     result
 }
 
 /// Write a `u8`-sized `value` to `port`.
-pub unsafe fn outw(value: u16, port: u16) {
-    llvm_asm!("outw %ax, %dx" :: "{dx}"(port), "{ax}"(value) :: "volatile");
+pub unsafe fn outw(value: u16, mut _port: u16) {
+    asm!("outw dx", out("dx") _port, in("ax") value, options(pure, nomem));
 }
 
 /// Read a `u32`-sized value from `port`.
 pub unsafe fn inl(port: u16) -> u32 {
     let result: u32;
-    llvm_asm!("inl %dx, %eax" : "={eax}"(result) : "{dx}"(port) :: "volatile");
+    asm!("inl dx", out("eax") result, in("dx") port, options(pure, nomem));
     result
 }
 
 /// Write a `u32`-sized `value` to `port`.
-pub unsafe fn outl(value: u32, port: u16) {
-    llvm_asm!("outl %eax, %dx" :: "{dx}"(port), "{eax}"(value) :: "volatile");
+pub unsafe fn outl(value: u32, mut _port: u16) {
+    asm!("outl dx", out("dx") _port, in("eax") value, options(pure, nomem));
 }


### PR DESCRIPTION
Update to modern rust asm macro, and remove unnecessary features

llvm_asm never became stable, and causes the build to fail under stable and nightly compilers.

https://github.com/rust-lang/rust/pull/91728

duplicate of #11